### PR TITLE
Add BNS domain support for withdrawals

### DIFF
--- a/cogs/account.py
+++ b/cogs/account.py
@@ -100,7 +100,7 @@ class AccountCog(commands.Cog):
                 ctx.error = True
                 return
             try:
-                ctx.destination = RegexUtil.find_address_match(msg.content)
+                ctx.destination = RegexUtil.find_address_match(msg.content, config.Config.instance().get_bns_enabled())
             except AddressMissingException:
                 await Messages.send_usage_dm(msg.author, SEND_INFO)
                 ctx.error = True
@@ -109,7 +109,8 @@ class AccountCog(commands.Cog):
                 await Messages.send_error_dm(msg.author, "You can only specify 1 destination address")
                 ctx.error = True
                 return
-            if not Validators.is_valid_address(ctx.destination):
+            #Disallow invalid Banano addresses but allow BNS domains
+            if not Validators.is_valid_address(ctx.destination) and not "." in ctx.destination:
                 await Messages.send_error_dm(msg.author, "The destination address you specified is invalid")
                 ctx.error = True
                 return

--- a/config.py
+++ b/config.py
@@ -197,3 +197,11 @@ class Config(object):
         elif 'restrictions' in self.yaml and 'no_stats_channels' in self.yaml['restrictions']:
             return self.yaml['restrictions']['no_stats_channels']
         return default
+
+    def get_bns_enabled(self) -> bool:
+        default = False
+        if not self.has_yaml():
+            return default
+        elif 'bns' in self.yaml:
+            return self.yaml['bns']
+        return default

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -85,3 +85,5 @@ server:
   # Callback is at $host:$port/callback (e.g. 127.0.0.1:11337/callback)
   host: 127.0.0.1
   port: 11337
+
+bns: true

--- a/rpc/client.py
+++ b/rpc/client.py
@@ -5,6 +5,7 @@ import socket
 import os
 from config import Config
 from typing import List, Tuple
+from util.util import Utils, BNSResolvingException
 
 class RPCClient(object):
     _instance = None
@@ -31,7 +32,7 @@ class RPCClient(object):
             cls._instance = None
 
     async def make_request(self, req_json: dict):
-        async with self.session.post(self.node_url ,json=req_json, timeout=300) as resp:
+        async with self.session.post(self.node_url, json=req_json, timeout=300) as resp:
             respJson = await resp.json()
             if resp.status != 200:
                 self.logger.error(f"RPC request failed with status {resp.status}")
@@ -61,7 +62,18 @@ class RPCClient(object):
         return None
 
     async def send(self, id: str, source: str, destination: str, amount: str) -> str:
-        """Make transaction, return hash if successful"""
+        """Make transaction, return hash if successful, resolve BNS domain if relevant"""
+        if '.' in destination:
+            #if . is in destination, this is a BNS domain not a Banano address
+            #resolve it into a Banano address if possible
+            bnsrespjson = await Utils.resolve_bns(destination)
+            resolved = False
+            if 'domain' in bnsrespjson:
+                if 'resolved_address' in bnsrespjson['domain']:
+                    destination = bnsrespjson['domain']['resolved_address']
+                    resolved = True
+            if not resolved:
+                raise BNSResolvingException("Could not resolve BNS Domain to address")
         send_action = {
             'action': 'send',
             'wallet': Config.instance().wallet,

--- a/util/regex.py
+++ b/util/regex.py
@@ -29,13 +29,16 @@ class RegexUtil():
         raise AmountMissingException("amount_not_found")
 
     @staticmethod
-    def find_address_match(input_text: str) -> str:
+    def find_address_match(input_text: str, bns_enabled: bool = False) -> str:
         """Find nano/banano address in a string"""
         if Env.banano():
             address_regex = '(?:ban)(?:_)(?:1|3)(?:[13456789abcdefghijkmnopqrstuwxyz]{59})'
         else:
             address_regex = '(?:nano|xrb)(?:_)(?:1|3)(?:[13456789abcdefghijkmnopqrstuwxyz]{59})'
         matches = re.findall(address_regex, input_text)
+        #if bns not enabled, don't match bns domains so they can't be passed down to later functions
+        if bns_enabled:
+            matches += re.findall('[0-9a-z]+\.[0-9a-z]+', input_text)
         if len(matches) == 1:
             return matches[0]
         elif len(matches) > 1:

--- a/util/util.py
+++ b/util/util.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 from typing import List
 
+import aiohttp
 import asyncio
 import emoji
+import rapidjson as json
 import re
 import secrets
+
+class BNSResolvingException(Exception):
+    pass
 
 class Utils(object):
     """Generic utilities"""
@@ -29,3 +34,18 @@ class Utils(object):
     @staticmethod
     def random_float() -> float:
         return secrets.randbelow(100) / 100
+
+    @staticmethod
+    async def resolve_bns(domain_and_tld: str) -> dict:
+        parts = domain_and_tld.split('.')
+        async with aiohttp.ClientSession(json_serialize=json.dumps) as session:
+            async with session.post("https://api.creeper.banano.cc/banano/v1/account/bns", json={
+                'domain_name': parts[0],
+                'tld': parts[1],
+            }, timeout=300) as resp:
+                respJson = await resp.json()
+                if resp.status != 200:
+                    self.logger.error(f"BNS resolve request failed with status {resp.status}")
+                    self.logger.error(f"Request: {req_json}")
+                    self.logger.error(f"Response: {respJson}")
+                return respJson


### PR DESCRIPTION
Add support for resolving BNS domains into Banano addresses when withdrawing (send and probably the sendmax command). I did not have a node with `enable_control` (sorry) but I did test the PR by disabling a bunch of checks that required the node, and was able to see the BNS domain resolve into a Banano address in the `send` function in `rpc/client.py`.

It relies on ptera's spyglass API instead of doing the resolving locally as resolving locally would mean I would have to either reimplement BNS resolving in this repo, or messily import another library with its own RPC client. Hopefully that is okay.

`bns: true` must be in `config.yaml` to enable BNS support.

Can test by doing:
`!send 1 prussia.ban` (should work)
`!send 1 nishina247.mictest` (should work)
`!send 1 a.ban` (should not work)
`!send 1 doesnotexist.mictest` (should not work)